### PR TITLE
feat: Add retry implementation inspired by async-retry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ npm install retry-ignore-abort
 
 ## Quick Start
 
-First you need to add a reference to assertthat to your application.
+First you need to add a reference to `retry-ignore-abort` to your application:
 
 ```javascript
 const { retry, retryIgnoreAbort } = require('retry-ignore-abort');
@@ -34,8 +34,6 @@ import { retry, retryIgnoreAbort } from 'retry-ignore-abort';
 
 ### retry
 
-`retry` is inspired by [async-retry](https://github.com/zeit/async-retry) and has the same function signature.
-
 With it you can retry the execution of a function with exponentially increasing timeouts like so:
 
 ```javascript
@@ -47,8 +45,6 @@ const response = await retry(
 ```
 
 This will try to fetch `http://some-server/some-route` and retry in case of network errors.
-
-For an overview of all options and available callbacks see the [options documentation](https://github.com/tim-kos/node-retry#retryoperationoptions) of [retry](https://github.com/tim-kos/node-retry), which this is based on.
 
 ### retryIgnoreAbort
 
@@ -75,6 +71,33 @@ await retryIgnoreAbort(
   }
 );
 ```
+
+## Details
+
+### retry
+
+The full signature for retry is:
+
+```typescript
+const retry = <TValue> (
+  retryOperation: (retryCount: number) => Promise<TValue> | TValue,
+  options?: {
+    // The maximum amount of retries. Note that this __excludes__ the first try of the operation.
+    retries?: number = 5;
+    // The minimum amount of milliseconds between two tries.
+    minTimeout?: number = 1_000;
+    // The maximum amount of milliesconds between two tries.
+    maxTimeout?: number = 60_000;
+    // The factor with which the timeout grows exponentially.
+    factor?: number = 2;
+  }
+): Promise<TValue | undefined>;
+```
+
+Retry can throw several [defekt](https://github.com/thenativeweb/defekt) errors:
+
+- `OptionsInvalid` is thrown if the options given don't make sense.
+- `RetriesExceeded` is thrown if the operation fails more often than allowed. This error contains the last exception thrown by the operation on its `data` property.
 
 ## Running the build
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,34 @@ $ npm install retry-ignore-abort
 First you need to add a reference to assertthat to your application.
 
 ```javascript
-const { retryIgnoreAbort } = require('retry-ignore-abort');
+const { retry, retryIgnoreAbort } = require('retry-ignore-abort');
 ```
 
 If you use TypeScript, use the following code instead:
 
 ```typescript
-import { retryIgnoreAbort } from 'retry-ignore-abort';
+import { retry, retryIgnoreAbort } from 'retry-ignore-abort';
 ```
+
+### retry
+
+`retry` is inspired by [async-retry](https://github.com/zeit/async-retry) and has the same function signature.
+
+With it you can retry the execution of a function with exponentially increasing timeouts like so:
+
+```javascript
+const response = await retry(
+  () => {
+    return await axios('http://some-server/some-route');
+  }
+);
+```
+
+This will try to fetch `http://some-server/some-route` and retry in case of network errors.
+
+For an overview of all options and available callbacks see the [options documentation](https://github.com/tim-kos/node-retry#retryoperationoptions) of [retry](https://github.com/tim-kos/node-retry), which this is based on.
+
+### retryIgnoreAbort
 
 Then you can wrap a number of functions inside of a call to `retryIgnoreAbort`. The functions may be `async`, if needed, but synchronous functions work as well.
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,10 @@
+import { defekt } from 'defekt';
+
+const errors = defekt({
+  OptionsInvalid: {},
+  RetriesExceeded: {}
+});
+
+export {
+  errors
+};

--- a/lib/retry.ts
+++ b/lib/retry.ts
@@ -30,7 +30,7 @@ const retry = async function <TValue>(
   };
 
   if (options.maxTimeout < options.minTimeout) {
-    throw new errors.OptionsInvalid('Max timeout must be greate than min timeout.');
+    throw new errors.OptionsInvalid('Max timeout must be greater than min timeout.');
   }
 
   let timeout = options.minTimeout;

--- a/lib/retry.ts
+++ b/lib/retry.ts
@@ -1,0 +1,60 @@
+import { operation, OperationOptions } from 'retry';
+
+export interface RetryOptions extends OperationOptions {
+  randomize?: boolean;
+  onRetry?: (err: any, num: number) => Promise<void> | void;
+}
+
+export type RetryOperation<TValue> = (bail: (err?: any) => void, retryCount: number) => Promise<TValue> | TValue;
+
+const retry = async function <TValue>(
+  fn: RetryOperation<TValue>,
+  opts: RetryOptions = {}
+): Promise<TValue> {
+  return new Promise((resolve, reject): void => {
+    const op = operation(opts);
+
+    const bail = (err?: any): void => {
+      reject(err ?? new Error('Aborted'));
+    };
+
+    const onError = async (err: any, num: number): Promise<void> => {
+      if (err.bail) {
+        bail(err);
+
+        return;
+      }
+
+      const didRetry = op.retry(err);
+
+      if (!didRetry) {
+        reject(op.mainError());
+
+        return;
+      }
+
+      if (opts.onRetry) {
+        await opts.onRetry(err, num);
+      }
+    };
+
+    /* eslint-disable unicorn/consistent-function-scoping */
+    // Disabled due to bug: https://github.com/sindresorhus/eslint-plugin-unicorn/issues/372
+    const runAttempt = async (num: number): Promise<void> => {
+      try {
+        const result = await fn(bail, num);
+
+        resolve(result);
+      } catch (error) {
+        await onError(error, num);
+      }
+    };
+
+    op.attempt(runAttempt);
+  });
+  /* eslint-enable unicorn/consistent-function-scoping */
+};
+
+export {
+  retry
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -7790,8 +7790,7 @@
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-      "dev": true
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "reusify": {
       "version": "1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1341,7 +1341,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
       "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
-      "dev": true,
       "requires": {
         "xregexp": "4.0.0"
       }
@@ -1386,7 +1385,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/defekt/-/defekt-5.0.0.tgz",
       "integrity": "sha512-A16uAUlfiwlC/xGixS4ebJTqnSEqaBRCKFijeKxW5UYwEoSWzNuaQKa7OWsZ+zzW/I2itiDCl2ZZt4UqHaUQsg==",
-      "dev": true,
       "requires": {
         "humanize-string": "2.1.0"
       }
@@ -2373,7 +2371,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/humanize-string/-/humanize-string-2.1.0.tgz",
       "integrity": "sha512-sQ+hqmxyXW8Cj7iqxcQxD7oSy3+AXnIZXdUF9lQMkzaG8dtbKAB8U7lCtViMnwQ+MpdCKsO2Kiij3G6UUXq/Xg==",
-      "dev": true,
       "requires": {
         "decamelize": "^2.0.0"
       }
@@ -7790,7 +7787,8 @@
     "retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true
     },
     "reusify": {
       "version": "1.0.4",
@@ -9078,8 +9076,7 @@
     "xregexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
-      "dev": true
+      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,13 @@
   ],
   "main": "build/lib/index.js",
   "types": "build/lib/index.d.ts",
-  "dependencies": {},
+  "dependencies": {
+    "retry": "0.12.0"
+  },
   "devDependencies": {
+    "@types/retry": "0.12.0",
     "assertthat": "5.1.0",
+    "axios": "0.19.0",
     "roboter": "10.1.12",
     "semantic-release-configuration": "1.0.7"
   },

--- a/package.json
+++ b/package.json
@@ -15,10 +15,9 @@
   "main": "build/lib/index.js",
   "types": "build/lib/index.d.ts",
   "dependencies": {
-    "retry": "0.12.0"
+    "defekt": "5.0.0"
   },
   "devDependencies": {
-    "@types/retry": "0.12.0",
     "assertthat": "5.1.0",
     "axios": "0.19.0",
     "roboter": "10.1.12",

--- a/test/unit/retryTests.ts
+++ b/test/unit/retryTests.ts
@@ -18,7 +18,7 @@ suite('retry', function (): void {
         }
       );
     } catch (ex) {
-      assert.that(ex.message).is.equalTo('Max timeout must be greate than min timeout.');
+      assert.that(ex.message).is.equalTo('Max timeout must be greater than min timeout.');
       assert.that(ex.code).is.equalTo('EOPTIONSINVALID');
     }
   });

--- a/test/unit/retryTests.ts
+++ b/test/unit/retryTests.ts
@@ -8,8 +8,23 @@ const sleep = async (milliseconds: number): Promise<void> => new Promise((resolv
 suite('retry', function (): void {
   this.timeout(5_000);
 
+  test('throws an error if the min timeout is greater than the max timeout.', async (): Promise<void> => {
+    try {
+      await retry(
+        (): number => 5,
+        {
+          minTimeout: 5_000,
+          maxTimeout: 1_000
+        }
+      );
+    } catch (ex) {
+      assert.that(ex.message).is.equalTo('Max timeout must be greate than min timeout.');
+      assert.that(ex.code).is.equalTo('EOPTIONSINVALID');
+    }
+  });
+
   test('resolves to the value the retry operation returns.', async (): Promise<void> => {
-    const result = await retry(async (bail, num): Promise<string> => {
+    const result = await retry(async (num): Promise<string> => {
       if (num < 2) {
         throw new Error('foo');
       }
@@ -22,67 +37,13 @@ suite('retry', function (): void {
     assert.that(result).is.equalTo('bar 2');
   });
 
-  test('calling bail stops the retry process.', async (): Promise<void> => {
-    try {
-      await retry(
-        async (bail, num): Promise<void> => {
-          if (num === 2) {
-            bail(new Error('Wont retry'));
-          }
-
-          throw new Error(`Test ${num}`);
-        },
-        { retries: 3 }
-      );
-    } catch (error) {
-      assert.that(error.message).is.equalTo('Wont retry');
-    }
-  });
-
-  test('setting the bail property on a thrown error stops the retry process.', async (): Promise<void> => {
-    let retries = 0;
-
-    try {
-      await retry(
-        async (): Promise<void> => {
-          retries += 1;
-          await sleep(100);
-          const err = new Error('Wont retry') as any;
-
-          err.bail = true;
-          throw err;
-        },
-        { retries: 3 }
-      );
-    } catch (error) {
-      assert.that(error.message).is.equalTo('Wont retry');
-    }
-
-    assert.that(retries).is.equalTo(1);
-  });
-
   test('works with a synchronous operation.', async (): Promise<void> => {
     const result = await retry((): number => 5);
 
     assert.that(result).is.equalTo(5);
   });
 
-  test('throwing an error works with a synchronous operation.', async function (): Promise<void> {
-    this.timeout(10_000);
-
-    try {
-      await retry(
-        (bail, num): void => {
-          throw new Error(`Test ${num}`);
-        },
-        { retries: 2 }
-      );
-    } catch (error) {
-      assert.that(error.message).is.equalTo('Test 3');
-    }
-  });
-
-  test('works with multiple retries.', async function (): Promise<void> {
+  test('throws an error if the retries are exceeded.', async function (): Promise<void> {
     this.timeout(10_000);
 
     let retries = 0;
@@ -90,23 +51,17 @@ suite('retry', function (): void {
     try {
       await retry(
         (): void => {
+          retries += 1;
           throw new Error(`Test ${retries}`);
         },
         {
-          retries: 2,
-          onRetry (err, i): void {
-            if (err) {
-              /* eslint-disable no-console */
-              console.log(`Retry error : ${err.message}`);
-              /* eslint-enable no-console */
-            }
-
-            retries = i;
-          }
+          retries: 2
         }
       );
     } catch (error) {
-      assert.that(retries).is.equalTo(2);
+      assert.that(error.message).is.equalTo('Retried too many times.');
+      assert.that(error.code).is.equalTo('ERETRIESEXCEEDED');
+      assert.that(retries).is.equalTo(3);
     }
   });
 
@@ -116,8 +71,8 @@ suite('retry', function (): void {
     const resolveOrder: number[] = [];
 
     await retry(
-      async (bail, retryCount): Promise<void> => {
-        if (retryCount === 1) {
+      async (retryCount): Promise<void> => {
+        if (retryCount === 0) {
           await new Promise((resolve): void => {
             setTimeout(resolve, 5_000);
           });
@@ -127,6 +82,6 @@ suite('retry', function (): void {
       }
     );
 
-    assert.that(resolveOrder).is.equalTo([ 1 ]);
+    assert.that(resolveOrder).is.equalTo([ 0 ]);
   });
 });

--- a/test/unit/retryTests.ts
+++ b/test/unit/retryTests.ts
@@ -1,0 +1,132 @@
+import { assert } from 'assertthat';
+import { retry } from '../../lib/retry';
+
+const sleep = async (milliseconds: number): Promise<void> => new Promise((resolve): void => {
+  setTimeout(resolve, milliseconds);
+});
+
+suite('retry', function (): void {
+  this.timeout(5_000);
+
+  test('resolves to the value the retry operation returns.', async (): Promise<void> => {
+    const result = await retry(async (bail, num): Promise<string> => {
+      if (num < 2) {
+        throw new Error('foo');
+      }
+
+      await sleep(50);
+
+      return `bar ${num}`;
+    });
+
+    assert.that(result).is.equalTo('bar 2');
+  });
+
+  test('calling bail stops the retry process.', async (): Promise<void> => {
+    try {
+      await retry(
+        async (bail, num): Promise<void> => {
+          if (num === 2) {
+            bail(new Error('Wont retry'));
+          }
+
+          throw new Error(`Test ${num}`);
+        },
+        { retries: 3 }
+      );
+    } catch (error) {
+      assert.that(error.message).is.equalTo('Wont retry');
+    }
+  });
+
+  test('setting the bail property on a thrown error stops the retry process.', async (): Promise<void> => {
+    let retries = 0;
+
+    try {
+      await retry(
+        async (): Promise<void> => {
+          retries += 1;
+          await sleep(100);
+          const err = new Error('Wont retry') as any;
+
+          err.bail = true;
+          throw err;
+        },
+        { retries: 3 }
+      );
+    } catch (error) {
+      assert.that(error.message).is.equalTo('Wont retry');
+    }
+
+    assert.that(retries).is.equalTo(1);
+  });
+
+  test('works with a synchronous operation.', async (): Promise<void> => {
+    const result = await retry((): number => 5);
+
+    assert.that(result).is.equalTo(5);
+  });
+
+  test('throwing an error works with a synchronous operation.', async function (): Promise<void> {
+    this.timeout(10_000);
+
+    try {
+      await retry(
+        (bail, num): void => {
+          throw new Error(`Test ${num}`);
+        },
+        { retries: 2 }
+      );
+    } catch (error) {
+      assert.that(error.message).is.equalTo('Test 3');
+    }
+  });
+
+  test('works with multiple retries.', async function (): Promise<void> {
+    this.timeout(10_000);
+
+    let retries = 0;
+
+    try {
+      await retry(
+        (): void => {
+          throw new Error(`Test ${retries}`);
+        },
+        {
+          retries: 2,
+          onRetry (err, i): void {
+            if (err) {
+              /* eslint-disable no-console */
+              console.log(`Retry error : ${err.message}`);
+              /* eslint-enable no-console */
+            }
+
+            retries = i;
+          }
+        }
+      );
+    } catch (error) {
+      assert.that(retries).is.equalTo(2);
+    }
+  });
+
+  test(`retries can't overtake each other.`, async function (): Promise<void> {
+    this.timeout(10_000);
+
+    const resolveOrder: number[] = [];
+
+    await retry(
+      async (bail, retryCount): Promise<void> => {
+        if (retryCount === 1) {
+          await new Promise((resolve): void => {
+            setTimeout(resolve, 5_000);
+          });
+        }
+
+        resolveOrder.push(retryCount);
+      }
+    );
+
+    assert.that(resolveOrder).is.equalTo([ 1 ]);
+  });
+});


### PR DESCRIPTION
I took the main logic from [async-retry](https://github.com/zeit/async-retry) and rewrote it to be more in line with our style.

- I changed the default for the `randomize` parameter back to `false` to be more in line with the original settings from [retry](https://github.com/tim-kos/node-retry).
- I rewrote the code to use async/await instead of the previous `Promise.resolve(...)` approach, because async/await is much more readable in this case and reduces the complexity of error handling.