### PR TITLE
fix: update defekt

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,10 +1,9 @@
 import { defekt } from 'defekt';
 
-const errors = defekt({
-  OptionsInvalid: {},
-  RetriesExceeded: {}
-});
+class OptionsInvalid extends defekt({ code: 'OptionsInvalid' }) {}
+class RetriesExceeded extends defekt({ code: 'RetriesExceeded' }) {}
 
 export {
-  errors
+  OptionsInvalid,
+  RetriesExceeded
 };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,9 @@
 import { retry } from './retry';
 import { retryIgnoreAbort } from './retryIgnoreAbort';
+import * as errors from './errors';
 
 export {
   retry,
-  retryIgnoreAbort
+  retryIgnoreAbort,
+  errors
 };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,7 @@ import { retryIgnoreAbort } from './retryIgnoreAbort';
 import * as errors from './errors';
 
 export {
+  errors,
   retry,
-  retryIgnoreAbort,
-  errors
+  retryIgnoreAbort
 };

--- a/lib/retry.ts
+++ b/lib/retry.ts
@@ -1,6 +1,6 @@
-import { errors } from './errors';
 import { promisify } from 'util';
 import { retryIgnoreAbort } from './retryIgnoreAbort';
+import * as errors from './errors';
 
 const sleep = promisify(setTimeout);
 
@@ -48,7 +48,7 @@ const retry = async function <TValue>(
     async (ex): Promise<'retry'> => {
       currentRetry += 1;
       if (currentRetry > options.retries) {
-        throw new errors.RetriesExceeded('Retried too many times.', { data: { ex }});
+        throw new errors.RetriesExceeded({ message: 'Retried too many times.', cause: ex });
       }
 
       await sleep(timeout);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2078,9 +2078,9 @@
       }
     },
     "defekt": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/defekt/-/defekt-6.0.2.tgz",
-      "integrity": "sha512-pMXTtCbb3OpKnf3McYwUFERjWQ2siu1oT5T25WljaB4/aRGvhL9IWYmYJ6T5DrvNUhNxxCfuARJ5g4nDmp6jNA=="
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/defekt/-/defekt-7.0.3.tgz",
+      "integrity": "sha512-k7zAO9I30pwvTZ80ncgNcvRjoy35WF3ujpIvu2hys/QfBxhqfUY3GW3SCZM2WA0+5WDwQJqo4CFWb6WkNvAtxg=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -8830,6 +8830,12 @@
         "typescript": "4.2.3"
       },
       "dependencies": {
+        "defekt": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/defekt/-/defekt-6.0.2.tgz",
+          "integrity": "sha512-pMXTtCbb3OpKnf3McYwUFERjWQ2siu1oT5T25WljaB4/aRGvhL9IWYmYJ6T5DrvNUhNxxCfuARJ5g4nDmp6jNA==",
+          "dev": true
+        },
         "globby": {
           "version": "11.0.3",
           "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "build/lib/index.js",
   "types": "build/lib/index.d.ts",
   "dependencies": {
-    "defekt": "6.0.2"
+    "defekt": "7.0.3"
   },
   "devDependencies": {
     "assertthat": "5.2.6",

--- a/test/unit/retryTests.ts
+++ b/test/unit/retryTests.ts
@@ -1,6 +1,7 @@
 import { assert } from 'assertthat';
 import { CustomError } from 'defekt';
 import { retry } from '../../lib/retry';
+import * as errors from '../../lib/errors';
 
 const sleep = async (milliseconds: number): Promise<void> => new Promise((resolve): void => {
   setTimeout(resolve, milliseconds);
@@ -20,7 +21,7 @@ suite('retry', function (): void {
       );
     } catch (ex: unknown) {
       assert.that((ex as CustomError).message).is.equalTo('Max timeout must be greater than min timeout.');
-      assert.that((ex as CustomError).code).is.equalTo('EOPTIONSINVALID');
+      assert.that((ex as CustomError).code).is.equalTo(errors.OptionsInvalid.code);
     }
   });
 
@@ -61,7 +62,7 @@ suite('retry', function (): void {
       );
     } catch (ex: unknown) {
       assert.that((ex as CustomError).message).is.equalTo('Retried too many times.');
-      assert.that((ex as CustomError).code).is.equalTo('ERETRIESEXCEEDED');
+      assert.that((ex as CustomError).code).is.equalTo(errors.RetriesExceeded.code);
       assert.that(retries).is.equalTo(3);
     }
   });


### PR DESCRIPTION
BREAKING CHANGE


The errors thrown by the library have changed, if you relied on their error codes before, you have to use the exported errors.